### PR TITLE
fix compatibility issues with latest scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+install_requires = ["scipy<1.14.0"]
+
 setuptools.setup(
     name="eigentools", 
     version="2.2112",
@@ -13,6 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/dedalusproject/eigentools",
     packages=setuptools.find_packages(),
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"


### PR DESCRIPTION
when solving an Eigenproblem, this fixes issue with "csr_matrix has no attribute 'A'". 

Seems to be due to scipy 1.14.0 which is very recent.